### PR TITLE
I2C/SPI Combined Driver

### DIFF
--- a/examples/bmp5xx_spi_simpletest.py
+++ b/examples/bmp5xx_spi_simpletest.py
@@ -4,16 +4,19 @@
 import time
 
 import board
+from digitalio import DigitalInOut, Direction
 
 from adafruit_bmp5xx import BMP5XX
 
 SEALEVELPRESSURE_HPA = 1013.25
 
-# I2C setup
-i2c = board.I2C()  # uses board.SCL and board.SDA
-# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+# SPI setup
+spi = board.SPI()  # uses board.SCL and board.SDA
+spi = board.SPI()
+cs = DigitalInOut(board.D10)
+cs.direction = Direction.OUTPUT
+bmp = BMP5XX(spi=spi, cs=cs)
 
-bmp = BMP5XX(i2c)
 
 bmp.sea_level_pressure = SEALEVELPRESSURE_HPA
 


### PR DESCRIPTION
This relies on the changes from: https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/59 So that should be merged before this is.

Adds SPI support by using new functionality pending addition to `adafruit_register` 

This should be a major version bump if merged because the class name changed from the bus specific `BMP5XX_I2C` to the now generic `BMP5XX`.

The bus type gets determined by whether `spi` and `cs` or `i2c` are passed to the constructor. Everything gets handled externally and code that using the driver has the same API after the BMP5XX class is created.

Internally the command and chip_id register descriptors were changed from UnaryStructs to RW/RO Bits. This was because the (Register_SPI)[https://github.com/adafruit/Adafruit_CircuitPython_Register_SPI] classes that I started from only had Bit and Bits implemented, no Struct(s). The change doesn't make any difference in the API. 

I tested both I2C and SPI examples successfully on `Adafruit CircuitPython 10.0.0-beta.3 on 2025-08-29; Adafruit Feather RP2040 with rp2040`