### PR TITLE
Fixing Temp measurements to work below freezing

### DIFF
--- a/adafruit_bmp5xx.py
+++ b/adafruit_bmp5xx.py
@@ -285,7 +285,7 @@ class BMP5XX:
 
         # check if sign bit is set and correct the value if so
         if raw_t & 0b100000000000000000000000:
-            raw_t -= 1 << 24 
+            raw_t -= 1 << 24
 
         return raw_t / 65536.0
 

--- a/adafruit_bmp5xx.py
+++ b/adafruit_bmp5xx.py
@@ -282,6 +282,11 @@ class BMP5XX:
     def temperature(self) -> float:
         """Temperature in degress C."""
         raw_t = self._temperature
+
+        # check if sign bit is set and correct the value if so
+        if raw_t & 0b100000000000000000000000:
+            raw_t -= 1 << 24 
+
         return raw_t / 65536.0
 
     @property

--- a/adafruit_bmp5xx.py
+++ b/adafruit_bmp5xx.py
@@ -180,8 +180,8 @@ class BMP5XX:
     pressure_oor_interrupt: bool = RWBit(BMP5_REG_INT_STATUS, 3)
     """True when pressure is OOR."""
 
-    _temperature = ROBits(24, BMP5XX_REG_TEMP_DATA_XLSB, 0, 3)
-    _pressure = ROBits(24, BMP5XX_REG_PRESS_DATA_XLSB, 0, 3)
+    _temperature = ROBits(24, BMP5XX_REG_TEMP_DATA_XLSB, 0, 3, signed=True)
+    _pressure = ROBits(24, BMP5XX_REG_PRESS_DATA_XLSB, 0, 3, signed=True)
     _mode = RWBits(2, BMP5XX_REG_ODR_CONFIG, 0)
 
     deep_disabled = RWBit(BMP5XX_REG_ODR_CONFIG, 7)
@@ -282,11 +282,6 @@ class BMP5XX:
     def temperature(self) -> float:
         """Temperature in degress C."""
         raw_t = self._temperature
-
-        # check if sign bit is set and correct the value if so
-        if raw_t & 0b100000000000000000000000:
-            raw_t -= 1 << 24
-
         return raw_t / 65536.0
 
     @property


### PR DESCRIPTION
Hi, I bought this sensor to help with some tests using high-altitude balloons and noticed an issue with the temperature readings, where once the sensor got below freezing, everything would jump up to 255.  It looks like it's supposed to be a signed value, but is getting read in as an unsigned one.  

This is a quick fix that corrects that by adding a simple check to look for the signed bit and correct the temperature value.  

Here's the readings with the fix: 
<img width="380" height="107" alt="tempTestFix" src="https://github.com/user-attachments/assets/ddbd489a-5e4b-4bff-8208-2e1d85d35dee" />

And here's an example of the original error:
<img width="388" height="63" alt="tempTestFail2" src="https://github.com/user-attachments/assets/96bfab68-e4a1-4321-90b1-8f7cfee0c8a1" />
